### PR TITLE
Add error handling for JSON Parse failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sf-hiera-aws changelog
 
+## 0.0.8 (11 January 2017)
+
+ * Add handling of JSON Parse failures that occur behind squid when not in AWS.
+
 ## 0.0.7 (2 June 2016)
 
  * Add support for ElastiCache Replication Groups
@@ -29,4 +33,3 @@
 ## 0.0.1 (2 September 2015)
 
  * Initial release
-

--- a/lib/hiera/backend/sf_hiera_aws_backend.rb
+++ b/lib/hiera/backend/sf_hiera_aws_backend.rb
@@ -16,7 +16,7 @@ class Hiera
                     @instance_identity = JSON.parse(http.request(Net::HTTP::Get.new('/latest/dynamic/instance-identity/document')).body)
                 rescue Errno::EHOSTUNREACH, Net::OpenTimeout, Timeout::Error
                     Hiera.warn('No link-local endpoint - can\'t calculate region')
-                rescue JSON::ParserError => e
+                rescue JSON::ParserError
                     Hiera.warn('JSON Parse error - probably not in AWS')
                 rescue => e
                     Hiera.warn("Exception while finding instance identity: #{e.inspect}"

--- a/lib/hiera/backend/sf_hiera_aws_backend.rb
+++ b/lib/hiera/backend/sf_hiera_aws_backend.rb
@@ -13,11 +13,12 @@ class Hiera
                     http = Net::HTTP.new('169.254.169.254', 80)
                     http.open_timeout = 1
                     http.read_timeout = 1
-                    @instance_identity = JSON.parse(http.request(Net::HTTP::Get.new('/latest/dynamic/instance-identity/document')).body)
+                    request = http.request(Net::HTTP::Get.new('/latest/dynamic/instance-identity/document')).body
+                    @instance_identity = JSON.parse(request)
                 rescue Errno::EHOSTUNREACH, Net::OpenTimeout, Timeout::Error
                     Hiera.warn('No link-local endpoint - can\'t calculate region')
                 rescue JSON::ParserError
-                    Hiera.warn('JSON Parse error - probably not in AWS')
+                    Hiera.warn("HTTP response from link-local endpoint returned invalid JSON: #{request}")
                 rescue => e
                     Hiera.warn("Exception while finding instance identity: #{e.inspect}"
                 end

--- a/lib/hiera/backend/sf_hiera_aws_backend.rb
+++ b/lib/hiera/backend/sf_hiera_aws_backend.rb
@@ -16,6 +16,10 @@ class Hiera
                     @instance_identity = JSON.parse(http.request(Net::HTTP::Get.new('/latest/dynamic/instance-identity/document')).body)
                 rescue Errno::EHOSTUNREACH, Net::OpenTimeout, Timeout::Error
                     Hiera.warn('No link-local endpoint - can\'t calculate region')
+                rescue JSON::ParserError => e
+                    Hiera.warn('JSON Parse error - probably not in AWS')
+                rescue => e
+                    Hiera.warn("Exception while finding instance identity: #{e.inspect}"
                 end
             end
 

--- a/sf-hiera-aws.gemspec
+++ b/sf-hiera-aws.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
     spec.name          = 'sf-hiera-aws'
-    spec.version       = '0.0.7'
+    spec.version       = '0.0.8'
     spec.authors       = ['Jon Topper','Mike Griffiths']
     spec.email         = ['jon@scalefactory.com','mike@scalefactory.com']
 

--- a/sf-hiera-aws.gemspec
+++ b/sf-hiera-aws.gemspec
@@ -5,8 +5,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 Gem::Specification.new do |spec|
     spec.name          = 'sf-hiera-aws'
     spec.version       = '0.0.8'
-    spec.authors       = ['Jon Topper','Mike Griffiths']
-    spec.email         = ['jon@scalefactory.com','mike@scalefactory.com']
+    spec.authors       = ['Jon Topper','Mike Griffiths','Jack Thomas']
+    spec.email         = ['jon@scalefactory.com','mike@scalefactory.com','jack@scalefactory.com']
 
     spec.summary       = 'Hiera backend for querying AWS resources'
     spec.homepage      = 'https://github.com/scalefactory/sf-hiera-aws'


### PR DESCRIPTION
Intermittent failures occur when using sf-hiera-aws behind squid in vagrant.

This handles a JSON Parse failure and assumes the machine is not in AWS.