### PR TITLE
Add ASG instance information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # sf-hiera-aws changelog
 
+## 0.0.9 (23 January 2017)
+
+ * Add autoscaling status information to EC2 instance
+
 ## 0.0.8 (11 January 2017)
 
  * Add handling of JSON Parse failures that occur behind squid when not in AWS.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ## About
 
-This is a Hiera backend to provide access to the EC2 API for a small number of resource types. Its purpose is to prevent it from ever being necessary to copy and paste EC2, RDS and ElastiCache addresses from the AWS console into Puppet configs anywhere.
+This is a Hiera backend to provide access to the EC2 API for a small number of
+resource types. Its purpose is to prevent it from ever being necessary to copy
+and paste EC2, RDS, AutoScaling Instance members, and ElastiCache addresses from
+the AWS console into Puppet configs anywhere.
 
 ## Usage and Setup
 
@@ -14,9 +17,12 @@ To add this backend to hiera, edit `/etc/puppet/hiera.yaml`:
   - sf_hiera_aws
 ```
 
-This plugin will attempt to use a machine's IAM role to perform AWS lookups - this is the recommended method of operation. 
+This plugin will attempt to use a machine's IAM role to perform AWS lookups -
+this is the recommended method of operation. 
 
-Absent an IAM role, the plugin will fall back to looking up credentials in the environment. Use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` variables.
+Absent an IAM role, the plugin will fall back to looking up credentials in the
+environment. Use `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION`
+variables.
 
 The IAM role will need the following permissions:
 
@@ -28,7 +34,8 @@ The IAM role will need the following permissions:
                 "Action": [
                     "ec2:DescribeInstances",
                     "rds:DescribeDBInstances",
-                    "elasticache:DescribeCacheClusters"
+                    "elasticache:DescribeCacheClusters",
+                    "autoscaling:DescribeAutoScalingGroups"
                 ],
                 "Effect": "Allow",
                 "Resource": [
@@ -41,8 +48,15 @@ The IAM role will need the following permissions:
 
 ## Configuration
 
-The plugin expects to find a configuration file under `/etc/puppet/sf_hiera_aws.yaml`, defining how we look up named keys.  The keys at the top level of this file determine the names of the hiera keys the plugin will provide; the configuration determines how these are looked up.
-Additional configuration can be given in files under `/etc/puppet/sf_hiera_aws.d`, which are evaluated in alphanumerical order. If a duplicate key is encountered in files evaluated later, this will override the earlier config.
+The plugin expects to find a configuration file under
+`/etc/puppet/sf_hiera_aws.yaml`, defining how we look up named keys.  The keys
+at the top level of this file determine the names of the hiera keys the plugin
+will provide; the configuration determines how these are looked up.
+
+Additional configuration can be given in files under
+`/etc/puppet/sf_hiera_aws.d`, which are evaluated in alphanumerical order. If a
+duplicate key is encountered in files evaluated later, this will override the
+earlier config.
 
 ### Example - EC2 nodes by tag
 
@@ -60,9 +74,16 @@ aws_am_search_nodes:
     - :private_dns_name
 ```
 
-The value of `return` here is also the default, and so can be omitted. You can use any of the methods listed at http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Instance.html to obtain other details from the Instance object.  Calls to this key will return a list of hashes, each containing `instace_id`, `private_ip_address` and `private_dns_name` keys.
+The value of `return` here is also the default, and so can be omitted. You can
+use any of the methods listed at
+http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Instance.html to obtain other
+details from the Instance object.  Calls to this key will return a list of
+hashes, each containing `instace_id`, `private_ip_address` and
+`private_dns_name` keys.
 
-Note that by default all EC2 instances will be returned, including stopped instances. To return only the running instances, add a filter as shown in this example.
+Note that by default all EC2 instances will be returned, including stopped
+instances. To return only the running instances, add a filter as shown in this
+example.
 
 ### Example - EC2 nodes by tag, single item list
 
@@ -75,7 +96,9 @@ aws_am_search_nodes:
   return: :private_ip_address
 ```
 
-Here, we pass a single symbol to the `return` argument.  In this case, we'll get back a list of strings containing private ip addresses (rather than a list of hashes).
+Here, we pass a single symbol to the `return` argument.  In this case, we'll get
+back a list of strings containing private ip addresses (rather than a list of
+hashes).
 
 
 
@@ -87,9 +110,14 @@ aws_am_bullseye_rds:
   db_instance_identifier: "%{::sf_location}-%{::sf_environment}-db"
 ```
 
-Calls to `:rds_db_instance` type keys return the instance identifier, endpoint address and endpoint port in a hash.
-Pass a `return` key with value `:hostname` to have the hostname of the first matching instance returned.
-Pass a `return` key with value `:hostname_and_port` to have a `"<hostname>:<port>"` string of the first matching instance returned.
+Calls to `:rds_db_instance` type keys return the instance identifier, endpoint
+address and endpoint port in a hash.
+
+Pass a `return` key with value `:hostname` to have the hostname of the first
+matching instance returned.
+
+Pass a `return` key with value `:hostname_and_port` to have a
+`"<hostname>:<port>"` string of the first matching instance returned.
 
 ### Example - ElastiCache cluster by name
 
@@ -99,9 +127,14 @@ aws_am_bullseye_redis:
   cache_cluster_id: "%{::sf_location}-%{::sf_environment}-redis"
 ```
 
-Calls to `:elasticache_cache_cluster` type keys return a list of cache nodes, their IDs and endpoint address/ports.
-Pass a `return` key with value `:hostname` to have a list of hostnames of keys of all cache nodes matching the cache_cluster_id returned.
-Pass a `return` key with value `:hostname_and_port` to have a list of `"<hostname>:<port>"` strings returned.
+Calls to `:elasticache_cache_cluster` type keys return a list of cache nodes,
+their IDs and endpoint address/ports.
+
+Pass a `return` key with value `:hostname` to have a list of hostnames of keys
+of all cache nodes matching the cache_cluster_id returned.
+
+Pass a `return` key with value `:hostname_and_port` to have a list of
+`"<hostname>:<port>"` strings returned.
 
 ### Example - ElastiCache replication group by name
 
@@ -111,13 +144,52 @@ aws_app_redis:
   replication_group_id: "%{::sf_location}-%{::sf_environment}-redis"
 ```
 
-Calls to `:elasticache_replication_group` return a list of replication groups, their primary endpoints and node group members.
-Pass a `return` key with value `:primary_endpoint` to have the hostname for the primary end point of the node group returned.
-Pass a `return` key with value `:primary_endpoint_and_port` to have the hostname and port returned as a colon-separated string.
-Pass a `return` key with value `:read_endpoints` to return an array of read endpoint hostnames, if a `replication_group_id` is specified. Returns `nil` if `replication_group_id` is unspecified.
-Pass a `return` key with value `:read_endpoints_with_ports` to return an array of read endpoint hostnames and ports as colon delimted strongs. Returns `nil` if `replication_group_id` is unspecified.
+Calls to `:elasticache_replication_group` return a list of replication groups,
+their primary endpoints and node group members.
+
+Pass a `return` key with value `:primary_endpoint` to have the hostname for the
+primary end point of the node group returned.
+
+Pass a `return` key with value `:primary_endpoint_and_port` to have the hostname
+and port returned as a colon-separated string.
+
+Pass a `return` key with value `:read_endpoints` to return an array of read
+endpoint hostnames, if a `replication_group_id` is specified. Returns `nil` if
+`replication_group_id` is unspecified.
+
+Pass a `return` key with value `:read_endpoints_with_ports` to return an array
+of read endpoint hostnames and ports as colon delimted strongs. Returns `nil` if
+`replication_group_id` is unspecified.
+
+### Example - AutoScaling Instance members
+
+```
+---
+aws_asg_group:
+  type:                     :autoscaling_group
+  auto_scaling_group_names: ["euwest1-test-api"]
+  return:                   :instance_details_inservice_ip
+```
+
+Calls to `:autoscaling_group` return a list of autoscaling groups and
+instance-id.
+
+Pass a `return` key with value `:instance_details_inservice_ip` to have the
+instance IP's returned for any matching instances in those autoscaling groups
+that are in the 'InService' state. This prevents nodes which are coming online,
+or have been marked for termination as appearing in this list.
+
+You will need to setup an ASG Lifecycle hook to put the machine into a Waiting
+state for slightly more that your puppet run, e.g. 20 minutes.
 
 ## Notes
 
-* The order in which items are returned, for example EC2 nodes matching a tag, is undefined. If you are using an array of items in a configuration file template, for example, you are advised to sort the array in the template. This eliminates the likelihood of unnecessary configuration file changes, and the consequential unnecessary restart of dependent services.
-* By default, all EC2 instances are returned, including those in a non-running state. To return only running instances, add a filter on `name: instance-state-name` and `values: ['running']` as per the example above.
+* The order in which items are returned, for example EC2 nodes matching a tag,
+  is undefined. If you are using an array of items in a configuration file
+  template, for example, you are advised to sort the array in the template. This
+  eliminates the likelihood of unnecessary configuration file changes, and the
+  consequential unnecessary restart of dependent services.
+* By default, all EC2 instances are returned, including those in a non-running
+  state. To return only running instances, add a filter on
+  `name: instance-state-name` and `values: ['running']` as per the example
+  above.

--- a/sf-hiera-aws.gemspec
+++ b/sf-hiera-aws.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
     spec.name          = 'sf-hiera-aws'
-    spec.version       = '0.0.8'
+    spec.version       = '0.0.9'
     spec.authors       = ['Jon Topper','Mike Griffiths','Jack Thomas']
     spec.email         = ['jon@scalefactory.com','mike@scalefactory.com','jack@scalefactory.com']
 

--- a/spec/unit/asg_test.rb
+++ b/spec/unit/asg_test.rb
@@ -1,0 +1,179 @@
+require 'spec_helper'
+
+class Hiera
+    module Backend
+        describe Sf_hiera_aws_backend do
+            before do
+                Hiera.stubs(:debug)
+                Hiera.stubs(:warn)
+
+                stub_request(:get, 'http://169.254.169.254/latest/dynamic/instance-identity/document').to_return(body: fake_metadata.to_json)
+
+                Aws.config.update(stub_responses: true)
+
+                class Config
+                    @config = {}
+                    class << self
+                        def [](key)
+                            @config[key]
+                        end
+                    end
+                end
+
+                @asg_stub_small = {
+                    auto_scaling_groups: [
+                        {
+                            auto_scaling_group_name: "euwest1-test-backend",
+                            launch_configuration_name: "euwest1-test-backend_1484914261",
+                            load_balancer_names: [],
+                            min_size: 1,
+                            max_size: 1,
+                            desired_capacity: 1,
+                            default_cooldown: 300,
+                            availability_zones: ["eu-west-1b","eu-west-1c","eu-west-1a"],
+                            health_check_type: "EC2",
+                            health_check_grace_period: 120,
+                            created_time: Time.now(),
+                            instances: [
+                                {
+                                    instance_id: "i-123abc12",
+                                    availability_zone: "eu-west-1c",
+                                    lifecycle_state: "InService",
+                                    health_status: "Healthy",
+                                    launch_configuration_name: 'euwest1-test-backend_1484914261',
+                                    protected_from_scale_in: false
+                                }
+                            ]
+                        }
+                    ]
+                }
+                @asg_stub_big = {
+                    auto_scaling_groups: [
+                        {
+                            auto_scaling_group_name: "euwest1-test-api",
+                            launch_configuration_name: "euwest1-test-api_14844234231",
+                            load_balancer_names: ["euwest1-test-lb-api"],
+                            min_size: 3,
+                            max_size: 10,
+                            desired_capacity: 3,
+                            default_cooldown: 300,
+                            availability_zones: ["eu-west-1b","eu-west-1c","eu-west-1a"],
+                            health_check_type: "EC2",
+                            health_check_grace_period: 120,
+                            created_time: Time.now(),
+                            instances: [
+                                {
+                                    instance_id: "i-123abc13",
+                                    availability_zone: "eu-west-1a",
+                                    lifecycle_state: "InService",
+                                    health_status: "Healthy",
+                                    launch_configuration_name: 'euwest1-test-api_14844234231',
+                                    protected_from_scale_in: false
+                                },
+                                {
+                                    instance_id: "i-123abc14",
+                                    availability_zone: "eu-west-1a",
+                                    lifecycle_state: "InService",
+                                    health_status: "Healthy",
+                                    launch_configuration_name: 'euwest1-test-api_14844234231',
+                                    protected_from_scale_in: false
+                                },
+                                {
+                                    instance_id: "i-123abc15",
+                                    availability_zone: "eu-west-1a",
+                                    lifecycle_state: "Pending",
+                                    health_status: "Healthy",
+                                    launch_configuration_name: 'euwest1-test-api_14844234231',
+                                    protected_from_scale_in: false
+                                }
+                            ]
+                        }
+                    ]
+                }
+
+                @ec2_stub = { reservations: [ {
+                    instances: [
+                        {
+                            instance_id:        'i-123abc13',
+                            private_ip_address: '10.10.10.11',
+                            private_dns_name:   'ip-10-10-10-11.eu-west-1.compute.internal',
+                        },
+                        {
+                            instance_id:        'i-123abc14',
+                            private_ip_address: '10.10.10.12',
+                            private_dns_name:   'ip-10-10-10-12.eu-west-1.compute.internal',
+                        }
+                    ]
+                } ] }
+            end
+
+            describe '#lookup' do
+
+                it 'should perform asg lookup by name' do
+                    config_yaml = YAML.load(<<-EOF.unindent)
+                    ---
+                    aws_asg_group:
+                      type:                     :autoscaling_group
+                      auto_scaling_group_names: ["euwest1-test-backend"]
+                    EOF
+
+                    backend = Hiera::Backend::Sf_hiera_aws_backend.new
+                    backend.expects(:aws_config).returns(config_yaml)
+
+                    autoscaling = Aws::AutoScaling::Client.new()
+                    asg_stub_single = @asg_stub_small.clone
+                    autoscaling.stub_responses(:describe_auto_scaling_groups, asg_stub_single)
+                    backend.expects(:get_autoscaling_client).returns(autoscaling)
+
+                    expect(backend.lookup('aws_asg_group', nil, nil, nil)).to eq([
+                        {
+                            'auto_scaling_group_name' => "euwest1-test-backend",
+                            'launch_configuration_name' => "euwest1-test-backend_1484914261",
+                            'load_balancer_names' => [],
+                            'instances' => [
+                                {
+                                    'instance_id' => "i-123abc12",
+                                    'availability_zone' => "eu-west-1c",
+                                    'lifecycle_state' => "InService",
+                                    'health_status' => "Healthy",
+                                    'launch_configuration_name' => 'euwest1-test-backend_1484914261',
+                                    'protected_from_scale_in' => false
+                                }
+                            ]
+                        }
+                    ])
+                end
+
+                it 'should perform asg lookup by name and get ip addresses of InService nodes' do
+                    config_yaml = YAML.load(<<-EOF.unindent)
+                    ---
+                    aws_asg_group:
+                      type:                     :autoscaling_group
+                      auto_scaling_group_names: ["euwest1-test-api"]
+                      return:                   :instance_details_inservice_ip
+                    EOF
+
+                    backend = Hiera::Backend::Sf_hiera_aws_backend.new
+                    backend.expects(:aws_config).returns(config_yaml)
+
+                    autoscaling = Aws::AutoScaling::Client.new()
+                    ec2 = Aws::EC2::Client.new()
+                    
+                    asg_stub = @asg_stub_big.clone
+                    autoscaling.stub_responses(:describe_auto_scaling_groups, asg_stub)
+                    backend.expects(:get_autoscaling_client).returns(autoscaling)
+
+                    ec2_stub = @ec2_stub.clone
+                    ec2.stub_responses(:describe_instances, ec2_stub)
+                    backend.expects(:get_ec2_client).returns(ec2)
+
+                    expect(backend.lookup('aws_asg_group', nil, nil, nil)).to eq([
+                        {"private_ip_address"=>"10.10.10.11"},
+                        {"private_ip_address"=>"10.10.10.12"}
+                    ])
+                end
+
+            end
+        end
+    end
+end


### PR DESCRIPTION
This allows ASG instance information to be returned.

In particular the `return` option `instance_details_inservice_ip` which returns the instance IP's for the selected group which match the ASG Launch status of 'InService'. This will stop instances that have been flagged from a ScalingIn event from being marked as useful in a  puppet run.

This will require the setting up of an ASG Lifecycle hook to put the machine into a Waiting
state for slightly more that the puppet run, e.g. 20 minutes.